### PR TITLE
Fix workflow token permission alerts

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     permissions:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     permissions:


### PR DESCRIPTION
## Summary
- declare explicit top-level read-only token permissions in the code quality workflow
- declare explicit top-level read-only token permissions in the unit test workflow
- retain job-level least-privilege declarations

This addresses CodeQL/OpenSSF Scorecard alerts #60 and #61 (`TokenPermissionsID`).

Alerts #59 (`BranchProtectionID`) and #77 (`CodeReviewID`) are repository-policy/history findings and are not dismissed by this code change. The active `main` ruleset already mitigates their core risks; closure depends on compliant reviewed merges and a subsequent Scorecard scan.