### PR TITLE
fix: correct pass^k metric naming and comments

### DIFF
--- a/thinkingbox/cli/agg_main.py
+++ b/thinkingbox/cli/agg_main.py
@@ -185,7 +185,7 @@ class Metrics(BaseModel):
     mean_pass_ci_low: float = 0.0
     mean_pass_ci_high: float = 0.0
     unbiased_pass_at_k: list[tuple[int, float]] = Field(default_factory=list)
-    unbiased_pass_power_k: list[tuple[int, float]] = Field(default_factory=list)
+    pass_power_k: list[tuple[int, float]] = Field(default_factory=list)
 
 
 def pass_at_k_unbiased(n, c, k: int):
@@ -222,17 +222,20 @@ def pass_at_k_unbiased(n, c, k: int):
     return 1.0 - float(np.prod(1.0 - k / denom_range))
 
 
-def pass_power_k_unbiased(n: int, c: int, k: int):
+def pass_power_k(n: int, c: int, k: int):
     """
-    Computes the unbiased pass^k metric for a set of test results.
+    Computes the pass^k metric for a set of test results.
 
-    pass^k is defined as the probability that a test case passes in all of k independent runs,
-    assuming unbiased sampling. It is calculated as (mean pass rate) ** k, i.e., the k-th power
+    pass^k is defined as the probability that a test case passes in all of k independent runs. It is calculated as (mean pass rate) ** k, i.e., the k-th power
     of the fraction of runs that passed.
 
     This differs from pass@k, which is the probability that at least one of k runs passes.
     pass@k is computed as 1 minus the probability that all k runs fail, whereas pass^k is the
     probability that all k runs succeed.
+
+    Unlike pass@k, we deliberately use a biased estimator for pass^k. An unbiased estimator is (c choose k)/(n choose k),
+    but it is zero whenever c < k, providing little differentiation among difficult cases. We instead use (c/n)^k, which retains a
+    non-zero signal even when c > 0.
 
     Args:
         n (int): Total number of runs
@@ -240,7 +243,7 @@ def pass_power_k_unbiased(n: int, c: int, k: int):
         k (int): Number of independent runs to consider.
 
     Returns:
-        float: The unbiased pass^k metric.
+        float: The pass^k metric.
     """
     assert k > 0, "pass^k requires k > 0"
     assert c <= n, "pass^k requires c <= n"
@@ -434,9 +437,7 @@ def aggregate_results(results: dict[str, PerTestCaseResults]) -> Metrics:
         total_pass += correct_runs
         for k in ks:
             pass_at_k_list[k].append(pass_at_k_unbiased(n=runs, c=correct_runs, k=k))
-            pass_power_k_list[k].append(
-                pass_power_k_unbiased(n=runs, c=correct_runs, k=k)
-            )
+            pass_power_k_list[k].append(pass_power_k(n=runs, c=correct_runs, k=k))
 
     out.runs_per_test = runs
     out.mean_pass = (total_pass / out.total_runs) if (out.total_runs) else 0.0
@@ -447,7 +448,7 @@ def aggregate_results(results: dict[str, PerTestCaseResults]) -> Metrics:
     out.unbiased_pass_at_k = [
         (k, safe_mean(v, default=0.0)) for k, v in pass_at_k_list.items()
     ]
-    out.unbiased_pass_power_k = [
+    out.pass_power_k = [
         (k, safe_mean(v, default=0.0)) for k, v in pass_power_k_list.items()
     ]
     return out
@@ -467,9 +468,9 @@ def print_metrics(metrics: Metrics):
         print("Pass@k:")
         for k, v in metrics.unbiased_pass_at_k:
             print(f"  pass@{k}: {v:.2f}")
-    if metrics.unbiased_pass_power_k:
+    if metrics.pass_power_k:
         print("Pass^k:")
-        for k, v in metrics.unbiased_pass_power_k:
+        for k, v in metrics.pass_power_k:
             print(f"  pass^{k}: {v:.2f}")
 
 


### PR DESCRIPTION
This pull request updates the naming of the `pass^k` metric in the `thinkingbox/cli/agg_main.py` file to clarify that it is a "biased" metric rather than "unbiased". Function and variable names, field names, and documentation are updated accordingly to maintain consistency throughout the codebase.

**Metric renaming and consistency updates:**

* Renamed the `unbiased_pass_power_k
This pull request updates the computation and reporting of the "pass^k" metric in `thinkingbox/cli/agg_main.py` to clarify its estimator and naming. The changes standardize the metric as a deliberately biased estimator, rename related variables and methods for clarity, and update all relevant usages throughout the codebase.

**Metric computation and estimator clarification:**

* Renamed the function `pass_power_k_unbiased` to `pass_power_k` and updated its docstring to clarify that it uses a biased estimator (`(c/n)^k`) instead of the unbiased estimator, explaining the rationale for this choice.
* Updated the aggregation logic to use the new `pass_power_k` function when computing per-test-case results.

**Variable and field renaming:**

* Renamed the `Metrics` model field from `unbiased_pass_power_k` to `pass_power_k` to reflect the new metric definition.
* Updated the assignment of aggregated results to use the new `pass_power_k` field instead of `unbiased_pass_power_k`.

**Output and reporting:**

* Updated the metrics printing logic to use the new `pass_power_k` field for displaying "Pass^k" results._power_k` field in the `Metrics` model to `pass_power_k` to reflect the correct nature of the metric being calculated.
* Renamed the function `pass_power_k_unbiased` to `pass_power_k`, and updated its docstring to remove references to "unbiased". [[1]](diffhunk://#diff-9913852415e626ac05d899004f8a35cb9f3a3508c912f9fb3f80b8cb3ab8a17fL255-R257) [[2]](diffhunk://#diff-9913852415e626ac05d899004f8a35cb9f3a3508c912f9fb3f80b8cb3ab8a17fL273-R273)
* Updated all usages of the old function and field names in the `aggregate_results` function to use the new names (`pass_power_k` and `pass_power_k`). [[1]](diffhunk://#diff-9913852415e626ac05d899004f8a35cb9f3a3508c912f9fb3f80b8cb3ab8a17fL489-R489) [[2]](diffhunk://#diff-9913852415e626ac05d899004f8a35cb9f3a3508c912f9fb3f80b8cb3ab8a17fL502-R500)
* Updated the `print_metrics` function to use `pass_power_k` instead of `unbiased_pass_power_k` for output.