### PR TITLE
Update contributor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ team:
 - [Tommy Guy](https://github.com/guyrt)
 - [Tuhin Kundu](https://github.com/TuhinKundu)
 - [Vadim Smolyakov](https://github.com/vasmolya-msft)
+- [Young Ko](https://github.com/YoungKo)
+- [Zhouchun Li](https://github.com/zhuochunli)
 
 ## Trademarks
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,10 @@ You can get a full list of the testcases in a certain file or directory, or of t
 
 This repository does not vendor third-party source code. All runtime and development dependencies are declared in `pyproject.toml` / `uv.lock` and installed from public package indexes (PyPI). Each dependency retains its own license.
 
+## Citation
+
+A paper describing ThinkingBox is coming soon.
+
 ## Acknowledgments
 
 ThinkingBox began in a private repository and was widely used by a group of
@@ -453,6 +457,7 @@ We also thank the following developers from the Microsoft Copilot Studio RL
 team:
 
 - [Aaron Dunlop](https://github.com/aarondunlopms)
+- Ali Keramati
 - [Anuar Sharafudinov](https://github.com/Mega4alik)
 - [Calvin Wang](https://github.com/calvinwang15)
 - Cosmin Popovici


### PR DESCRIPTION
# Summary

Recognize Ali Keramati, Young Ko, and Zhouchun Li for their contributions to the forthcoming ThinkingBox paper. The README also reserves a citation section for the arXiv reference once it is available.

## Changes

- Add Ali Keramati, Young Ko, and Zhouchun Li to the contributor list.
- Add a temporary "Paper coming soon" citation section.

## Test plan

- `git diff --check`
- Documentation-only change; no runtime tests required.

## Related issues

N/A