### PR TITLE
Update README with arXiv paper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ This repository does not vendor third-party source code. All runtime and develop
 
 ## Citation
 
-A paper describing ThinkingBox is coming soon.
+Read the [ThinkingBox paper](https://arxiv.org/abs/2608.19741).
 
 ## Acknowledgments
 


### PR DESCRIPTION
# Summary

The ThinkingBox paper is now available on arXiv, so the README should link readers directly to the publication instead of saying it is coming soon.

## Changes

- Replace the placeholder citation text with a link to the ThinkingBox paper on arXiv.
- Keep the update scoped to the README citation section.

## Test plan

- Verified the Markdown link targets `https://arxiv.org/abs/2608.19741`.

## Related issues

N/A